### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "cd ./Torrent2Drive_frontend && npm run build"
   },
   "engines": {
-    "node": ">= 4.0.0"
+     "node": "<=14.x.x",
+  "npm": "<=6.x.x"
   },
   "cacheDirectories": [
     "Torrent2Drive_frontend/node_modules",


### PR DESCRIPTION
To solve this error:
       Resolving node version >=10.16.0 <=14.x.x...
       Downloading and installing node 14.15.4...
       Bootstrapping npm >=6.0.0 (replacing 6.14.10)...
       npm >=6.0.0 installed
       
-----> Installing dependencies
       Installing node modules (package.json)
       npm ERR! code ERESOLVE
       npm ERR! ERESOLVE unable to resolve dependency tree
       npm ERR! 
       npm ERR! While resolving: drkang-strapi@0.1.0
       npm ERR! Found: knex@0.19.5
       npm ERR! node_modules/knex
       npm ERR!   knex@"<0.20.0" from the root project
       npm ERR! 
       npm ERR! Could not resolve dependency:
       npm ERR! peer knex@"^0.20.0" from strapi-connector-bookshelf@3.4.6
       npm ERR! node_modules/strapi-connector-bookshelf
       npm ERR!   strapi-connector-bookshelf@"3.4.6" from the root project
       npm ERR! 
       npm ERR! Fix the upstream dependency conflict, or retry
       npm ERR! this command with --force, or --legacy-peer-deps
       npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
       npm ERR! 
       npm ERR! See /tmp/npmcache.9OnCF/eresolve-report.txt for a full report.
       
       npm ERR! A complete log of this run can be found in:
       npm ERR!     /tmp/npmcache.9OnCF/_logs/2021-02-04T02_14_54_807Z-debug.log
-----> Build failed